### PR TITLE
Scott's simplest way to fix it

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -101,21 +101,27 @@ a:hover {
 }
 
 .incident-warning-image {
-  width: 25%;
   float: left;
   margin-right: 30px;
+  width: 180px;
+  aspect-ratio: auto 180 / 180;
+  height: 180px;
 }
 
 .python-image {
-  width: 25%;
   float: right;
   margin-left: 30px;
+  width: 180px;
+  aspect-ratio: auto 180 / 180;
+  height: 180px;
 }
 
 .azure-image {
-  width: 25%;
   float: left;
   margin-right: 30px;
+  width: 180px;
+  aspect-ratio: auto 180 / 180;
+  height: 180px;
 }
 
 


### PR DESCRIPTION
The simplest way to fix it was to review what the picture of you was doing. As you can see the image wasn't set to a % rather a pixel range. A change to the fixed pixel size stops it scaling up, and then knocking out the text. 

There is probably better ways to do it, like I was thinking about some kind of containerisation of each h3, with some kind of padding around it so that even when the image scales, it pushes space between them. I guess if you were doing this you could also figure out how to get the text to scale somehow also? not sure. Depends what you want to do right.